### PR TITLE
Update server when image/container is run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .idea/
 dev/
+
+valheim-data/
+valheim-server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM cm2network/steamcmd:latest
 
+
+# where the Valheim server is installed to
+ENV STEAM_HOME_DIR "/home/steam"
+
 # where the Valheim server is installed to
 ENV VALHEIM_SERVER_DIR "/home/steam/valheim-server"
-
-# install the Valheim server
-RUN ./steamcmd.sh +login anonymous \
-+force_install_dir $VALHEIM_SERVER_DIR \
-+app_update 896660 \
-validate +exit
 
 # changes the uuid and guid to 1000:1000, allowing for the files to save on GNU/Linux
 USER 1000:1000
@@ -29,9 +27,10 @@ EXPOSE 2457/udp
 EXPOSE 2458/udp
 
 VOLUME ${VALHEIM_DATA_DIR}
+VOLUME ${VALHEIM_SERVER_DIR}
 
 # copy over the modified server start script
-COPY start-valheim-server.sh ${VALHEIM_SERVER_DIR}
-WORKDIR ${VALHEIM_SERVER_DIR}
+COPY start-valheim-server.sh ${STEAM_HOME_DIR}
+WORKDIR ${STEAM_HOME_DIR}
 
 ENTRYPOINT ["./start-valheim-server.sh"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ your container after editing the config.
 |-----------------------------|-------------------------------------------|----------------------------|
 | `user`                      | Any UUID and GUID                         | 1000:1000                  |
 | `ports`                     | Any port, keep default internal ports     | Same internal and external |
-| `volumes`                   | Any path on your local system             | `./valheim-data`           |
+| `volumes`: 'valheim-data'   | Any path on your local system             | `./valheim-data`           |
+| `volumes`: 'valheim-server' | Any path on your local system             | `./valheim-server`         |
 | `VALHEIM_SERVER_NAME`       | Any string                                | "MyServer"                 |
 | `VALHEIM_WORLD_NAME`        | Any string                                | "NewWorld"                 |
 | `VALHEIM_PASSWORD`          | Any string                                | "password"                 |
@@ -71,6 +72,7 @@ docker run --name=valheim -d \
 --restart always \
 -p 2456:2456/udp -p 2457:2457/udp -p 2458:2458/udp \
 -v /home/sethmachine/valheim-data:/home/steam/valheim-data \
+-v /home/sethmachine/valheim-server:/home/steam/valheim-server \
 --env VALHEIM_SERVER_NAME="sethmachine'sServer" \
 --env VALHEIM_WORLD_NAME="AWholeNewWorld" \
 --env VALHEIM_PASSWORD="HardToGuessPassword" \

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ your container after editing the config.
 | `ports`                     | Any port, keep default internal ports     | Same internal and external |
 | `volumes`: 'valheim-data'   | Any path on your local system             | `./valheim-data`           |
 | `volumes`: 'valheim-server' | Any path on your local system             | `./valheim-server`         |
-| `VALHEIM_SERVER_NAME`       | Any string                                | "MyServer"                 |
-| `VALHEIM_WORLD_NAME`        | Any string                                | "NewWorld"                 |
-| `VALHEIM_PASSWORD`          | Any string                                | "password"                 |
+| `VALHEIM_SERVER_NAME`       | Any string                                | MyServer                 |
+| `VALHEIM_WORLD_NAME`        | Any string                                | NewWorld                 |
+| `VALHEIM_PASSWORD`          | Any string                                | password                 |
 
 
 ### Docker CLI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: sethmachineio/valheim-server
     user: "1000:1000"
     ports:
-      - 2456:2456
-      - 2457:2457
-      - 2458:2458
+      - 2456:2456/udp
+      - 2457:2457/udp
+      - 2458:2458/udp
     volumes:
       - ./valheim-data:/home/steam/valheim-data
       - ./valheim-server:/home/steam/valheim-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,6 @@ services:
       - ./valheim-data:/home/steam/valheim-data
       - ./valheim-server:/home/steam/valheim-server
     environment:
-      - VALHEIM_SERVER_NAME="MyServer"
-      - VALHEIM_WORLD_NAME="NewWorld"
-      - VALHEIM_PASSWORD="password"
+      - VALHEIM_SERVER_NAME=MyServer
+      - VALHEIM_WORLD_NAME=NewWorld
+      - VALHEIM_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - 2458:2458
     volumes:
       - ./valheim-data:/home/steam/valheim-data
+      - ./valheim-server:/home/steam/valheim-server
     environment:
       - VALHEIM_SERVER_NAME="MyServer"
       - VALHEIM_WORLD_NAME="NewWorld"

--- a/start-valheim-server.sh
+++ b/start-valheim-server.sh
@@ -39,6 +39,11 @@ echo "Valheim port is: $VALHEIM_PORT"
 echo "Valheim server name is: $VALHEIM_SERVER_NAME"
 echo "Valheim world name is: $VALHEIM_WORLD_NAME"
 
+steamcmd/steamcmd.sh +login anonymous \
++force_install_dir $VALHEIM_SERVER_DIR \
++app_update 896660 \
+validate +exit > "/home/steam/valheim-data/steamcmd_log.txt"
+
 cd $VALHEIM_SERVER_DIR
 # start the server as a background process to get its PID ("&" at end of command)
 # "&>>" means append all stdout and stderr to the log file

--- a/start-valheim-server.sh
+++ b/start-valheim-server.sh
@@ -45,6 +45,9 @@ steamcmd/steamcmd.sh +login anonymous \
 validate +exit > "/home/steam/valheim-data/steamcmd_log.txt"
 
 cd $VALHEIM_SERVER_DIR
+
+echo ./valheim_server.x86_64 -name $VALHEIM_SERVER_NAME -port $VALHEIM_PORT -world $VALHEIM_WORLD_NAME -password $VALHEIM_PASSWORD -savedir $VALHEIM_DATA_DIR > "/home/steam/valheim-data/call.txt"
+
 # start the server as a background process to get its PID ("&" at end of command)
 # "&>>" means append all stdout and stderr to the log file
 ./valheim_server.x86_64 -name $VALHEIM_SERVER_NAME \

--- a/start-valheim-server.sh
+++ b/start-valheim-server.sh
@@ -46,6 +46,7 @@ validate +exit > "/home/steam/valheim-data/steamcmd_log.txt"
 
 cd $VALHEIM_SERVER_DIR
 
+# Write the commandline, that will be executed to start the server, into the file "valheim-data/call.txt". Just for potential debugging purposes.
 echo ./valheim_server.x86_64 -name $VALHEIM_SERVER_NAME -port $VALHEIM_PORT -world $VALHEIM_WORLD_NAME -password $VALHEIM_PASSWORD -savedir $VALHEIM_DATA_DIR > "/home/steam/valheim-data/call.txt"
 
 # start the server as a background process to get its PID ("&" at end of command)


### PR DESCRIPTION
This PR makes the valheim-server to be installed in a persistent volumes.
Also it is updated whenever the entry script is called.
This allows updating without rebuilding the image and makes the server files viewable from the host.

Fixes #5  
 