### PR TITLE
Support Steam branch selection for Switch 2 crossplay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
 .git
+valheim-data/
+.env
+*.env
+*.patch
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .idea/
 dev/
 valheim-server/
+valheim-data/
+.env
+*.env
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM cm2network/steamcmd:latest
 
 USER root
-# Install PCREGREP (http://www.pcre.org/) to extract build IDs from the VDF format
-# PCREGREP allows for writing easy to understand regular expressions that can span multiple lines
-RUN apt-get update && apt-get install pcregrep -y && apt-get install git -y && apt-get install unzip
+# libpulse0 and libatomic1 are required by the Linux crossplay backend.
+RUN apt-get update && apt-get install -y --no-install-recommends git unzip libpulse0 libatomic1
 
 # where Steam is installed
 ENV STEAM_DIR "/home/steam/Steam"
@@ -16,6 +15,9 @@ ENV BEPINEX_PLUGINS_DIR "/home/steam/valheim-server/BepInEx/plugins"
 ENV BEPINEX_CONFIG_DIR "/home/steam/valheim-server/BepInEx/config"
 # the Steam app ID that uniquely identifies the server
 ENV VALHEIM_SERVER_APP_ID 896660
+# Steam release branch. Use default_old temporarily when console updates lag behind PC.
+ARG VALHEIM_SERVER_BRANCH=public
+ENV VALHEIM_SERVER_BRANCH=${VALHEIM_SERVER_BRANCH}
 # 1 enables a one time check to update the Valheim server whenever it is first started
 ENV VALHEIM_SERVER_UPDATE_ON_START_UP 1
 # 1 enables auto update; set to 0 to disable auto update
@@ -30,9 +32,8 @@ RUN cd ${STEAM_DIR} && git clone https://github.com/idelsink/b-log.git && apt-ge
 USER steam
 
 # install the Valheim server
-RUN ./steamcmd.sh +login anonymous \
-+force_install_dir $VALHEIM_SERVER_DIR \
-+app_update $VALHEIM_SERVER_APP_ID \
+RUN ./steamcmd.sh +force_install_dir "$VALHEIM_SERVER_DIR" +login anonymous \
++app_update "$VALHEIM_SERVER_APP_ID" -beta "$VALHEIM_SERVER_BRANCH" \
 validate +exit
 
 # copy bepinex to the server root
@@ -47,7 +48,7 @@ RUN chmod u+x $VALHEIM_SERVER_DIR/start_server_bepinex.sh
 ENV VALHEIM_DATA_DIR "/home/steam/valheim-data"
 # don't change the port unless you know what you are doing
 ENV VALHEIM_PORT 2456
-# server and world name are truncated after 1st white space
+# server and world names may contain spaces
 # you must set values to the server and world name otherwise the container will exit immediately
 ENV VALHEIM_SERVER_NAME=""
 ENV VALHEIM_WORLD_NAME=""
@@ -55,7 +56,7 @@ ENV VALHEIM_PASSWORD "password"
 # 1 allows viewing the server in the public list; 0 hides it (must join by IP)
 ENV VALHEIM_SERVER_PUBLIC 1
 ENV USE_BEPINEX 0
-# 1 enables crossplay (allows Xbox/Game Pass players to join); 0 for Steam-only
+# 1 enables PlayFab crossplay and join codes; 0 uses Steam-only networking.
 ENV VALHEIM_CROSSPLAY 0
 
 # the server needs these 3 ports exposed by default

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repo provides a Dockerfile that builds an image which runs a Valheim server
 
 This repo now provides **automatic update** for the Valheim server.  If this feature is enabled, a running Valheim server can automatically update itself as new Valheim updates are released, allowing a server to truly run 24/7.  
 
-Note you will still need to forward and open ports 2456, 2457, and 2458 (UDP protocol) on the host machine for the server to be listed and accessible.
+Enable crossplay in locally built images with `VALHEIM_CROSSPLAY=1`. It uses PlayFab relay networking and does not require router port forwarding. The default `VALHEIM_CROSSPLAY=0` retains Steam-only networking, which requires forwarding the configured UDP port and port+1 (default 2456–2457). See the [official dedicated-server guide](https://www.valheimgame.com/support/a-guide-to-dedicated-servers/).
+
+For the September 2026 Switch 2 version mismatch, see [SWITCH2-SETUP.md](SWITCH2-SETUP.md). The included Compose override enables crossplay, selects `default_old` at build time and runtime, and disables periodic updates. It must be used with a locally built image containing these scripts; the published Docker Hub image does not gain these settings just by setting environment variables.
 
 If you find this repo useful, I'd love to hear back in a note how you're using it.  If you use this repo to build on your own work, please provide a reference back to this repo's URL.
 
@@ -15,6 +17,14 @@ I also have written a complete guide here that covers how to set up your own ded
 For a detailed guide on how automatic update works, see this newer guide: [Automatic Update for Valheim Server](https://www.sethmachine.io/2021/02/11/host-valheim-with-docker/)
 
 ## Usage
+
+### Crossplay and release branches
+
+* `VALHEIM_CROSSPLAY`: `1` adds `-crossplay`; `0` (default) uses Steam-only networking. The Switch 2 Compose override sets this to `1`.
+* `VALHEIM_SERVER_BRANCH`: Steam branch to install and check for updates. Defaults to `public`. Also accepted as a Docker build argument. `default_old` is a temporary compatibility option, not a permanent version pin.
+* Server and world names support spaces. Keep your existing world name and save mount when replacing an image.
+
+After joining a crossplay server, open the in-game pause menu to find the join code. Game output, including crossplay session information, is in `VALHEIM_DATA_DIR/<world-name>-logs.txt`; `docker logs` primarily shows this wrapper's output. See the [crossplay FAQ](https://www.valheimgame.com/support/crossplay-faq/).
 
 You have two possibilities to run the container:
 
@@ -69,8 +79,8 @@ The subdirectory `worlds` can be empty or not exist at all.
 
 There are 8 environment parameters to customize the server's runtime behavior.  2 of these are required to be set, otherwise the container will exit immediately.
 
-* `VALHEIM_SERVER_NAME`: sets the server's name (**required**, truncated at first whitespace).
-* `VALHEIM_WORLD_NAME`: sets the world's name (**required**, truncated at first whitespace).
+* `VALHEIM_SERVER_NAME`: sets the server's name (**required**, spaces supported).
+* `VALHEIM_WORLD_NAME`: sets the world's name (**required**, spaces supported).
 * `VALHEIM_PASSWORD`: sets the server's password.
 * `VALHEIM_PORT`: sets the server's port (default is `2456`).  Recommended not to change this.
 * `VALHEIM_SERVER_PUBLIC`: allows the server to be listed in public server list (enable by default).  A value of `0` would mean the server is only joinable via IP.  

--- a/SWITCH2-SETUP.md
+++ b/SWITCH2-SETUP.md
@@ -1,0 +1,68 @@
+# Switch 2 crossplay setup
+
+The Dockerfile and launcher support opt-in crossplay, while the updater installs the selected Steam branch. The included `docker-compose.switch2.yml` enables crossplay and the temporary `default_old` workaround described in the September 11, 2026 developer announcement linked below.
+
+Crossplay requires `VALHEIM_CROSSPLAY=1`. The updater previously always fetched the public Steam branch, which could also undo a manual downgrade during a console patch delay. The override selects the compatible branch for both the image build and runtime updates.
+
+## Build and run on the server PC
+
+Use a checkout containing these changes and your existing Compose configuration. Keep your current world name, saved-data mount, and credentials instead of substituting this repository's sample values. Commands below assume your Compose file is named `docker-compose.yml` and the service is `valheim`.
+
+1. Build the patched image while the current server continues running:
+
+   ```sh
+   docker compose -f docker-compose.yml -f docker-compose.switch2.yml build valheim
+   ```
+
+2. Have players disconnect, then stop the server gracefully:
+
+   ```sh
+   docker compose -f docker-compose.yml stop -t 120 valheim
+   ```
+
+3. Make a backup copy of the **entire existing save-data directory** on the PC before switching game versions. Keep that copy outside the Docker build folder. This includes modern world subdirectories and older `.db`/`.fwl` files. Keep the original directory mounted at `/home/steam/valheim-data`.
+
+4. Start the patched server using the merged configuration:
+
+   ```sh
+   docker compose -f docker-compose.yml -f docker-compose.switch2.yml up -d --no-deps valheim
+   docker compose -f docker-compose.yml -f docker-compose.switch2.yml logs --tail=80 valheim
+   ```
+
+   Allow time for Steam to install/verify the selected branch. An unavailable branch causes startup to stop with an error rather than fall back to `public`.
+
+## Get the join code and connect
+
+This wrapper writes the actual game output to a world log in its mounted data directory. To show recent connection-related lines:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.switch2.yml exec valheim bash -lc 'tail -n 200 "$VALHEIM_DATA_DIR/$VALHEIM_WORLD_NAME-logs.txt" | grep -Ei "join code|PlayFab|game server connected|version|failed|error"'
+```
+
+Alternatively, join the world on PC, press Esc, and copy the join code from the pause menu. On Switch 2, use **Join Game → Add server** and enter that code. Each Steam player's game must also use the compatible `default_old` branch under **Properties → Game Versions & Betas** for this temporary workaround.
+
+The override disables BepInEx for this connection check. Worlds that depend on mods should be tested on a backup copy first.
+
+## What the override changes
+
+```yaml
+VALHEIM_CROSSPLAY: "1"
+VALHEIM_SERVER_BRANCH: default_old
+VALHEIM_SERVER_UPDATE_ON_START_UP: "1"
+VALHEIM_SERVER_AUTO_UPDATE: "0"
+USE_BEPINEX: "0"
+```
+
+The build uses `default_old` too. Startup verifies that branch, while periodic automatic updates stay off. `default_old` is a moving branch: a future restart/rebuild can install a newer build from it. Verify compatibility again after future patches.
+
+## Return to current releases
+
+Once Switch 2 receives the compatible update, change **both** `VALHEIM_SERVER_BRANCH` entries in `docker-compose.switch2.yml` (build argument and environment) to `public`, set `VALHEIM_SERVER_AUTO_UPDATE` to `"1"` if desired, rebuild, back up, and recreate using the same commands. Keep `VALHEIM_CROSSPLAY` enabled. Steam players should return their clients to the current public release too.
+
+## Verification and limits
+
+Run script checks with `python3 -m unittest discover -s tests -v`. They use fake SteamCMD responses and a fake server executable; they do not connect to Steam, touch real saves, or read credentials. Compose can be checked with `docker compose -f docker-compose.yml -f docker-compose.switch2.yml config --quiet`.
+
+A real Docker build, Switch-to-server connection, and graceful shutdown/save must also be tested on the host PC before using the image with an existing world.
+
+Sources: [official dedicated-server guide](https://www.valheimgame.com/support/a-guide-to-dedicated-servers/), [crossplay FAQ](https://www.valheimgame.com/support/crossplay-faq/), and [September 11 hotfix/workaround announcement](https://store.steampowered.com/oldnews/?appgroupname=Valheim&appids=892970&feed=steam_community_announcements).

--- a/docker-compose.switch2.yml
+++ b/docker-compose.switch2.yml
@@ -1,0 +1,16 @@
+# Merge with your EXISTING Compose file so the current world and data mount are retained.
+# Temporary September 2026 workaround; default_old is a moving Steam branch, not a version pin.
+services:
+  valheim:
+    image: valheim-server:switch2-local
+    build:
+      context: .
+      args:
+        VALHEIM_SERVER_BRANCH: default_old
+    stop_grace_period: 2m
+    environment:
+      VALHEIM_CROSSPLAY: "1"
+      VALHEIM_SERVER_BRANCH: default_old
+      VALHEIM_SERVER_UPDATE_ON_START_UP: "1"
+      VALHEIM_SERVER_AUTO_UPDATE: "0"
+      USE_BEPINEX: "0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   valheim:
     image: sethmachineio/valheim-server
     user: 1000:1000
+    stop_grace_period: 2m
     ports:
       - 2456:2456/udp
       - 2457:2457/udp

--- a/start-valheim-server.sh
+++ b/start-valheim-server.sh
@@ -24,13 +24,19 @@ function startValheimServer()
         INFO "The Valheim server is set to public visibility.  It will be visible in the server list.  Players will still need to enter the password to join"
     fi
 
-    cp $VALHEIM_DATA_DIR/plugins/* $BEPINEX_PLUGINS_DIR
-    cp $VALHEIM_DATA_DIR/config/* $BEPINEX_CONFIG_DIR
+    local crossplayArgs=()
+    if [ "${VALHEIM_CROSSPLAY:-0}" = 1 ]
+    then
+        crossplayArgs=(-crossplay)
+        INFO "Crossplay enabled. Find the join code in the in-game pause menu or world log."
+    fi
 
     EXECUTABLE="./valheim_server.x86_64"
 
     if [ "${USE_BEPINEX}" = 1 ]
     then
+        cp "$VALHEIM_DATA_DIR"/plugins/* "$BEPINEX_PLUGINS_DIR"
+        cp "$VALHEIM_DATA_DIR"/config/* "$BEPINEX_CONFIG_DIR"
         WARN "Using BepInEx modded valheim server!"
         # BepInEx-specific settings
         # NOTE: Do not edit unless you know what you are doing!
@@ -47,22 +53,15 @@ function startValheimServer()
     fi
 
 
-    cd $VALHEIM_SERVER_DIR
+    cd "$VALHEIM_SERVER_DIR" || return 1
     # start the server as a background process to get its PID ("&" at end of command)
-    # "&>>" means append all stdout and stderr to the log file
-    CROSSPLAY_ARG=""
-    if [ "${VALHEIM_CROSSPLAY}" = 1 ]; then
-        INFO "Crossplay is enabled"
-        CROSSPLAY_ARG="-crossplay"
-    fi
-
-    "$EXECUTABLE" -name $VALHEIM_SERVER_NAME \
-    -port $VALHEIM_PORT \
-    -world $VALHEIM_WORLD_NAME \
-    -password $VALHEIM_PASSWORD \
-    -public $VALHEIM_SERVER_PUBLIC \
-    -savedir $VALHEIM_DATA_DIR \
-    $CROSSPLAY_ARG &>> "/home/steam/valheim-data/$VALHEIM_WORLD_NAME-logs.txt" &
+    # Append all stdout and stderr to the world log.
+    "$EXECUTABLE" -batchmode -nographics -name "$VALHEIM_SERVER_NAME" \
+    -port "$VALHEIM_PORT" \
+    -world "$VALHEIM_WORLD_NAME" \
+    -password "$VALHEIM_PASSWORD" \
+    -public "$VALHEIM_SERVER_PUBLIC" \
+    -savedir "$VALHEIM_DATA_DIR" "${crossplayArgs[@]}" >> "$VALHEIM_DATA_DIR/$VALHEIM_WORLD_NAME-logs.txt" 2>&1 &
     VALHEIM_SERVER_PID=$!
     INFO "Valheim server PID is: $VALHEIM_SERVER_PID"
 }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,219 @@
+"""Exercise the real shell entrypoints with disposable fake game/Steam executables."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_INFO = '''
+"896660"
+{
+    "depots"
+    {
+        "branches"
+        {
+            "public"
+            {
+                "buildid" "200"
+            }
+            "default_old"
+            {
+                "description" "Previous release"
+                "timeupdated" "1234567890"
+                "buildid" "100"
+            }
+        }
+    }
+}
+'''
+
+
+class ServerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="valheim test ")
+        self.addCleanup(self.tmp.cleanup)
+        self.base = Path(self.tmp.name)
+        self.server = self.base / "server files"
+        self.data = self.base / "world data"
+        self.steam = self.base / "steam"
+        self.cmd = self.base / "steamcmd"
+        for path in (self.server / "steamapps", self.data, self.steam / "b-log", self.cmd):
+            path.mkdir(parents=True)
+        for name in ("start-valheim-server.sh", "update-valheim-server.sh",
+                     "shutdown-valheim-server.sh", "valheim-server-entrypoint.sh"):
+            shutil.copy2(ROOT / name, self.server / name)
+        (self.steam / "b-log/b-log.sh").write_text('''
+LOG_LEVEL_ALL() { :; }
+INFO() { printf '%s\\n' "$*"; }
+WARN() { printf '%s\\n' "$*"; }
+ERROR() { printf '%s\\n' "$*"; }
+FATAL() { printf '%s\\n' "$*"; }
+''')
+        fake_server = self.server / "valheim_server.x86_64"
+        fake_server.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+Path(os.environ["GAME_ARGS"]).write_text(json.dumps(sys.argv[1:]))
+print("Game server connected; join code 123456")
+''')
+        fake_server.chmod(0o755)
+        (self.cmd / "steamcmd.sh").write_text('python3 "$FAKE_STEAM_HELPER" "$@"\n')
+        helper = self.base / "fake_steam.py"
+        helper.write_text('''import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+with open(os.environ["STEAM_CALLS"], "a") as log:
+    log.write(json.dumps(args) + "\\n")
+if "+app_info_print" in args:
+    print(Path(os.environ["APP_INFO_FILE"]).read_text())
+    sys.exit(int(os.environ.get("QUERY_EXIT", "0")))
+if "+app_update" in args:
+    if os.environ.get("UPDATE_EXIT"):
+        sys.exit(int(os.environ["UPDATE_EXIT"]))
+    branch = args[args.index("-beta") + 1]
+    build = os.environ.get("INSTALL_BUILD", "100" if branch == "default_old" else "200")
+    manifest = Path(os.environ["VALHEIM_SERVER_DIR"]) / "steamapps/appmanifest_896660.acf"
+    manifest.write_text('"buildid" "' + build + '"\\n"BetaKey" "' + branch + '"\\n')
+''')
+        self.info = self.base / "app-info.vdf"
+        self.info.write_text(APP_INFO)
+        self.env = dict(os.environ, STEAM_DIR=str(self.steam), STEAMCMD_DIR=str(self.cmd),
+                        VALHEIM_SERVER_DIR=str(self.server), VALHEIM_DATA_DIR=str(self.data),
+                        VALHEIM_SERVER_APP_ID="896660", VALHEIM_SERVER_BRANCH="default_old",
+                        VALHEIM_CROSSPLAY="1", VALHEIM_SERVER_NAME="Friends Server",
+                        VALHEIM_WORLD_NAME="Existing World", VALHEIM_PASSWORD="synthetic test value",
+                        VALHEIM_PORT="2456", VALHEIM_SERVER_PUBLIC="1", USE_BEPINEX="0",
+                        VALHEIM_SERVER_UPDATE_ON_START_UP="1", VALHEIM_SERVER_AUTO_UPDATE="0",
+                        GAME_ARGS=str(self.base / "game-args.json"), STEAM_CALLS=str(self.base / "steam-calls.jsonl"),
+                        APP_INFO_FILE=str(self.info), FAKE_STEAM_HELPER=str(helper),
+                        LD_LIBRARY_PATH="")
+        self.write_manifest("200", "public")
+
+    def write_manifest(self, build, branch):
+        (self.server / "steamapps/appmanifest_896660.acf").write_text(
+            f'"buildid" "{build}"\n"BetaKey" "{branch}"\n')
+
+    def shell(self, code):
+        return subprocess.run(["bash", "-c", code], cwd=self.server, env=self.env,
+                              text=True, capture_output=True, timeout=10)
+
+    def entrypoint(self):
+        return self.shell('exec bash ./valheim-server-entrypoint.sh')
+
+    def calls(self):
+        path = Path(self.env["STEAM_CALLS"])
+        return [json.loads(line) for line in path.read_text().splitlines()] if path.exists() else []
+
+    def updates(self):
+        return [args for args in self.calls() if "+app_update" in args]
+
+    def test_crossplay_and_arguments_with_spaces(self):
+        for crossplay in ("1", "0"):
+            with self.subTest(crossplay=crossplay):
+                self.env["VALHEIM_CROSSPLAY"] = crossplay
+                result = self.entrypoint()
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                args = json.loads(Path(self.env["GAME_ARGS"]).read_text())
+                self.assertEqual("-crossplay" in args, crossplay == "1")
+                for flag, value in (("-name", "Friends Server"), ("-world", "Existing World"),
+                                    ("-savedir", str(self.data)), ("-password", "synthetic test value")):
+                    self.assertEqual(args[args.index(flag) + 1], value)
+                self.assertNotIn("synthetic test value", result.stdout + result.stderr)
+                self.assertIn("join code", (self.data / "Existing World-logs.txt").read_text())
+
+    def test_downgrade_installs_selected_branch_before_start(self):
+        result = self.entrypoint()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(len(self.updates()), 1)
+        args = self.updates()[0]
+        self.assertEqual(args[args.index("-beta") + 1], "default_old")
+        self.assertLess(args.index("+force_install_dir"), args.index("+login"))
+        self.assertTrue(Path(self.env["GAME_ARGS"]).exists())
+
+    def test_crossplay_remains_opt_in_without_switch_override(self):
+        self.env.pop("VALHEIM_CROSSPLAY")
+        result = self.entrypoint()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        args = json.loads(Path(self.env["GAME_ARGS"]).read_text())
+        self.assertNotIn("-crossplay", args)
+
+    def test_matching_branch_does_not_download_again(self):
+        self.write_manifest("100", "default_old")
+        result = self.entrypoint()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.updates(), [])
+
+    def test_branch_switch_with_identical_build_still_applies_beta(self):
+        self.write_manifest("100", "public")
+        result = self.entrypoint()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(len(self.updates()), 1)
+
+    def test_return_to_public_explicitly_resets_beta(self):
+        self.write_manifest("100", "default_old")
+        self.env["VALHEIM_SERVER_BRANCH"] = "public"
+        result = self.entrypoint()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        args = self.updates()[0]
+        self.assertEqual(args[args.index("-beta") + 1], "public")
+
+    def test_missing_branch_does_not_fall_back_or_launch(self):
+        self.info.write_text(APP_INFO.replace('"default_old"', '"another_branch"'))
+        result = self.entrypoint()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.updates(), [])
+        self.assertFalse(Path(self.env["GAME_ARGS"]).exists())
+        self.assertIn("no fallback to public", result.stdout)
+
+    def test_query_failure_does_not_stop_running_server(self):
+        self.env["QUERY_EXIT"] = "1"
+        result = self.shell('''
+source "$STEAM_DIR/b-log/b-log.sh"
+source ./update-valheim-server.sh
+shutdownValheimServer() { echo "UNEXPECTED_SHUTDOWN"; }
+checkForAndUpdateValheimServer
+''')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("UNEXPECTED_SHUTDOWN", result.stdout)
+        self.assertEqual(self.updates(), [])
+
+    def test_periodic_check_does_not_upgrade_old_branch_to_public(self):
+        self.write_manifest("100", "default_old")
+        result = self.shell('''
+source "$STEAM_DIR/b-log/b-log.sh"
+source ./update-valheim-server.sh
+shutdownValheimServer() { echo "UNEXPECTED_SHUTDOWN"; }
+startValheimServer() { echo "UNEXPECTED_RESTART"; }
+checkForAndUpdateValheimServer
+''')
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotIn("UNEXPECTED_", result.stdout)
+        self.assertEqual(self.updates(), [])
+
+    def test_failed_install_does_not_launch_wrong_version(self):
+        for key, value in (("UPDATE_EXIT", "1"), ("INSTALL_BUILD", "999")):
+            with self.subTest(failure=key):
+                self.env[key] = value
+                result = self.entrypoint()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(Path(self.env["GAME_ARGS"]).exists())
+                self.env.pop(key)
+
+    def test_invalid_configuration_is_rejected_before_steam(self):
+        for key, value in (("VALHEIM_SERVER_BRANCH", "bad branch"), ("VALHEIM_CROSSPLAY", "yes")):
+            with self.subTest(setting=key):
+                previous = self.env[key]
+                self.env[key] = value
+                result = self.entrypoint()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.calls(), [])
+                self.assertFalse(Path(self.env["GAME_ARGS"]).exists())
+                self.env[key] = previous
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update-valheim-server.sh
+++ b/update-valheim-server.sh
@@ -5,6 +5,7 @@
 VALHEIM_SERVER_APP_MANIFEST="$VALHEIM_SERVER_DIR/steamapps/appmanifest_896660.acf"
 # This is where the local/current build ID is stored
 VALHEIM_SERVER_LOCAL_BUILD_ID=""
+VALHEIM_SERVER_LOCAL_BRANCH=""
 # This is what Steam reports is the latest build ID
 VALHEIM_SERVER_REMOTE_BUILD_ID=""
 # Steam caches all app infos (contain build IDs); need to delete this file to get latest remote build IDs
@@ -21,7 +22,21 @@ function findAndSetLocalValheimServerBuildId(){
         local previousLocalBuildId=$VALHEIM_SERVER_LOCAL_BUILD_ID
     fi
 
-    VALHEIM_SERVER_LOCAL_BUILD_ID=$(cat ${VALHEIM_SERVER_APP_MANIFEST} | pcregrep -o1 -M '"buildid".*"([0-9]+)"')
+    VALHEIM_SERVER_LOCAL_BUILD_ID=""
+    VALHEIM_SERVER_LOCAL_BRANCH=""
+    if [[ ! -f "$VALHEIM_SERVER_APP_MANIFEST" ]]
+    then
+        WARN "No local app manifest found; the server needs to be installed"
+        return 1
+    fi
+    VALHEIM_SERVER_LOCAL_BUILD_ID=$(awk -F '"' '$2 == "buildid" && $4 ~ /^[0-9]+$/ { print $4; exit }' "$VALHEIM_SERVER_APP_MANIFEST")
+    VALHEIM_SERVER_LOCAL_BRANCH=$(awk -F '"' '$2 == "BetaKey" { print $4; exit }' "$VALHEIM_SERVER_APP_MANIFEST")
+    VALHEIM_SERVER_LOCAL_BRANCH=${VALHEIM_SERVER_LOCAL_BRANCH:-public}
+    if [[ -z "$VALHEIM_SERVER_LOCAL_BUILD_ID" ]]
+    then
+        ERROR "Could not read a valid build ID from the local app manifest"
+        return 1
+    fi
 
     if [[ ! -z "${previousLocalBuildId}" ]] && [[ ${previousLocalBuildId} != ${VALHEIM_SERVER_LOCAL_BUILD_ID} ]]
     then
@@ -37,21 +52,43 @@ function findAndSetRemoteValheimServerBuildId(){
     if [[ -f "${STEAM_CACHED_APP_INFO}" ]]
     then
         INFO "Deleting cached app info: $STEAM_CACHED_APP_INFO"
-        rm $STEAM_CACHED_APP_INFO
+        rm -- "$STEAM_CACHED_APP_INFO"
     fi
 
     # First update the app info get the latest build IDs from the Steam remote
-    INFO "Querying the remote server for the latest build ID for the Valheim server"
-    local appInfo=$(/bin/bash $STEAMCMD_DIR/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print 896660 +quit)
-    # Use a regex that looks for the build ID under the public branch
-    # TODO: use a VDF parser, as the regex will easily break if the line order changes
-    #                    "branches"
-    #                {
-    #                        "public"
-    #                        {
-    #                                "buildid"               "6437354"
-    #
-    VALHEIM_SERVER_REMOTE_BUILD_ID=$(echo "$appInfo" | pcregrep -o1 -M '"branches".*\n*.*{\n*.*"public".*\n*.*{.*\n*.*"buildid".*"([0-9]+)"')
+    local branch=${VALHEIM_SERVER_BRANCH:-public}
+    INFO "Querying Steam for the Valheim server build on branch $branch"
+    local appInfo
+    VALHEIM_SERVER_REMOTE_BUILD_ID=""
+    if ! appInfo=$(/bin/bash "$STEAMCMD_DIR/steamcmd.sh" +login anonymous +app_info_update 1 +app_info_print "$VALHEIM_SERVER_APP_ID" +quit)
+    then
+        ERROR "Steam could not return app information; update skipped"
+        return 1
+    fi
+    # SteamCMD prints VDF with one key or brace per line. Only inspect the
+    # requested branch inside branches; its position and field order can vary.
+    VALHEIM_SERVER_REMOTE_BUILD_ID=$(printf '%s\n' "$appInfo" | awk -F '"' -v branch="$branch" '
+        $2 == "branches" { branches = 1; next }
+        branches {
+            if ($0 ~ /^[[:space:]]*\{[[:space:]]*$/) { depth++; next }
+            if ($0 ~ /^[[:space:]]*\}[[:space:]]*$/) {
+                if (depth == 2) selected = 0
+                depth--
+                if (depth == 0) exit
+                next
+            }
+            if (depth == 1 && $2 == branch) selected = 1
+            if (depth == 2 && selected && $2 == "buildid" && $4 ~ /^[0-9]+$/) {
+                print $4
+                exit
+            }
+        }
+    ')
+    if [[ -z "$VALHEIM_SERVER_REMOTE_BUILD_ID" ]]
+    then
+        ERROR "No build ID found for branch $branch; update skipped (no fallback to public)"
+        return 1
+    fi
 
     INFO "The remote server build ID is $VALHEIM_SERVER_REMOTE_BUILD_ID"
 }
@@ -60,26 +97,29 @@ function assertLocalBuildIsLatest(){
     if [[ ${VALHEIM_SERVER_LOCAL_BUILD_ID} != ${VALHEIM_SERVER_REMOTE_BUILD_ID} ]]
     then
         ERROR "The local build differs from the remote build after updating.  Local build ID: $VALHEIM_SERVER_LOCAL_BUILD_ID.  Remote build ID: $VALHEIM_SERVER_REMOTE_BUILD_ID"
+        return 1
     else
         INFO "The local build ID is the same as the latest remote build ID"
     fi
 }
 
 function updateValheimServer(){
-    INFO "Updating the Valheim server"
-    /bin/bash $STEAMCMD_DIR/steamcmd.sh +login anonymous +force_install_dir $VALHEIM_SERVER_DIR +app_update $VALHEIM_SERVER_APP_ID +quit
+    INFO "Installing Valheim server branch ${VALHEIM_SERVER_BRANCH:-public}"
+    /bin/bash "$STEAMCMD_DIR/steamcmd.sh" +force_install_dir "$VALHEIM_SERVER_DIR" +login anonymous +app_update "$VALHEIM_SERVER_APP_ID" -beta "${VALHEIM_SERVER_BRANCH:-public}" validate +quit
 }
 
 function updateValheimServerIfNewerBuildExists(){
     # Only call this function before the first time the server ever starts up
     INFO "Checking to see if the Valheim server needs to be updated"
-    findAndSetLocalValheimServerBuildId
-    findAndSetRemoteValheimServerBuildId
-    if [[ "$VALHEIM_SERVER_LOCAL_BUILD_ID" = "$VALHEIM_SERVER_REMOTE_BUILD_ID" ]]
+    findAndSetLocalValheimServerBuildId || true
+    findAndSetRemoteValheimServerBuildId || return 1
+    if [[ "$VALHEIM_SERVER_LOCAL_BUILD_ID" = "$VALHEIM_SERVER_REMOTE_BUILD_ID" && "$VALHEIM_SERVER_LOCAL_BRANCH" = "${VALHEIM_SERVER_BRANCH:-public}" ]]
     then
         INFO "The Valheim server is already up to date with build ID $VALHEIM_SERVER_LOCAL_BUILD_ID"
     else
-        updateValheimServer
+        updateValheimServer || return 1
+        findAndSetLocalValheimServerBuildId || return 1
+        assertLocalBuildIsLatest || return 1
     fi
 }
 
@@ -87,17 +127,17 @@ function checkForAndUpdateValheimServer(){
     # Check if the Valheim server needs to be updated, and if so update it
     # Need to stop the Valheim server and then restart it afterwards
     INFO "Checking to see if the Valheim server needs to be updated"
-    findAndSetLocalValheimServerBuildId
-    findAndSetRemoteValheimServerBuildId
-    if [[ "$VALHEIM_SERVER_LOCAL_BUILD_ID" = "$VALHEIM_SERVER_REMOTE_BUILD_ID" ]]
+    findAndSetLocalValheimServerBuildId || return 1
+    findAndSetRemoteValheimServerBuildId || return 1
+    if [[ "$VALHEIM_SERVER_LOCAL_BUILD_ID" = "$VALHEIM_SERVER_REMOTE_BUILD_ID" && "$VALHEIM_SERVER_LOCAL_BRANCH" = "${VALHEIM_SERVER_BRANCH:-public}" ]]
     then
         INFO "The Valheim server is already up to date with build ID $VALHEIM_SERVER_LOCAL_BUILD_ID"
     else
         INFO "Updating the Valheim server from $VALHEIM_SERVER_LOCAL_BUILD_ID (old) to $VALHEIM_SERVER_REMOTE_BUILD_ID (new)"
         shutdownValheimServer
-        updateValheimServer
-        findAndSetLocalValheimServerBuildId
-        assertLocalBuildIsLatest
+        updateValheimServer || return 1
+        findAndSetLocalValheimServerBuildId || return 1
+        assertLocalBuildIsLatest || return 1
         startValheimServer
     fi
 }

--- a/valheim-server-entrypoint.sh
+++ b/valheim-server-entrypoint.sh
@@ -10,6 +10,19 @@ source start-valheim-server.sh
 source update-valheim-server.sh
 source shutdown-valheim-server.sh
 
+VALHEIM_SERVER_BRANCH=${VALHEIM_SERVER_BRANCH:-public}
+VALHEIM_CROSSPLAY=${VALHEIM_CROSSPLAY:-0}
+if [[ ! "$VALHEIM_SERVER_BRANCH" =~ ^[a-zA-Z0-9_-]+$ ]]
+then
+    FATAL "VALHEIM_SERVER_BRANCH must contain only letters, digits, underscores or hyphens"
+    exit 1
+fi
+if [[ "$VALHEIM_CROSSPLAY" != 0 && "$VALHEIM_CROSSPLAY" != 1 ]]
+then
+    FATAL "VALHEIM_CROSSPLAY must be 0 or 1"
+    exit 1
+fi
+
 # server name and world name need to be defined at runtime
 if [ -z "${VALHEIM_SERVER_NAME}" ]
 then
@@ -26,7 +39,11 @@ fi
 if [ "${VALHEIM_SERVER_UPDATE_ON_START_UP}" = 1 ]
 then
     INFO "Attempting one time update of the Valheim server on start up"
-    updateValheimServerIfNewerBuildExists
+    if ! updateValheimServerIfNewerBuildExists
+    then
+        FATAL "Could not install or verify the requested Steam branch. Server will not start."
+        exit 1
+    fi
 fi
 
 function terminateUpdateLoop(){


### PR DESCRIPTION
### Description

Add Steam branch selection at build time and runtime so the temporary Switch 2 `default_old` workaround survives updates. The Compose override enables crossplay, disables periodic updates and BepInEx, and preserves existing world settings and save mounts.

Includes crossplay libraries, quoted launch arguments, update-failure checks, and setup/rollback instructions. `default_old` is a moving branch, not a permanent version pin.

### Manual Tests

11 automated launcher/updater tests pass. Bash syntax and Compose validation pass. Live validation is pending:
- [ ] Docker image builds and starts.
- [ ] Switch 2 can join.
- [ ] Graceful shutdown saves a test world.

### Documentation

- [x] README settings documented.
- [x] SWITCH2-SETUP.md includes backup, deployment, join-code, and return-to-public steps.
